### PR TITLE
Fix emmet link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[Emmet](emmet.io) support for Atom.
+[Emmet](http://emmet.io) support for Atom.
 
 # How to get it
 


### PR DESCRIPTION
Previously, this tried to find the emmet.io file, now it links to their website correctly.
