### PR TITLE
Add more editor's syntax support

### DIFF
--- a/lib/editor-proxy.coffee
+++ b/lib/editor-proxy.coffee
@@ -130,8 +130,26 @@ module.exports =
   getSyntax: ->
     scopes = @editor.getCursorScopes()
     for scope in scopes
-      if /html/.test(scope)
+      # html & dialects
+      if /jade/.test(scope)
+        return "jade"
+      else if /haml/.test(scope)
+        return "haml"
+      else if /xsl/.test(scope)
+        return "xsl"
+      else if /xml/.test(scope)
+        return "xml"
+      else if /html/.test(scope)
         return "html"
+      # css & dialects
+      if /less/.test(scope)
+        return "less"
+      else if /scss/.test(scope)
+        return "scss"
+      else if /sass/.test(scope)
+        return "sass"
+      else if /stylus/.test(scope)
+        return "stylus"
       else if /css/.test(scope)
         return "css"
 


### PR DESCRIPTION
As suggested by @cobyism for issue #46, it was effectively the check that unable the stylus files to be understood.

After some tests, and observing the structure of the `/vendor/snippets.json` file, it appears to be better to return the good syntax for the file, as snippets.json allows to add syntax-specific snippets and extends syntaxes.

As side-effect, this pull request also correcting issue #40
