### PR TITLE
Use UI classes for prompt

### DIFF
--- a/lib/prompt.coffee
+++ b/lib/prompt.coffee
@@ -10,7 +10,7 @@ class PromptView extends View
 	@attach: -> new PromptView
 
 	@content: ->
-		@div class: 'emmet-prompt mini', =>
+		@div class: 'emmet-prompt tool-panel panel-bottom', =>
 			# @label class: 'emmet-prompt__label', outlet: 'label'
 			@div class: 'emmet-prompt__input', =>
 				@subview 'panelInput', new EditorView(mini: true)
@@ -26,7 +26,7 @@ class PromptView extends View
 	show: (@delegate={}) ->
 		@editor = @delegate.editor
 		@editorView = @delegate.editorView
-		@panelInput.setPlaceholderText @delegate.label or 'Enter Abbreviation'
+		@panelInput.setPlaceholderText @delegate.label or 'Enter abbreviation'
 		@updated = no
 
 		@attach()


### PR DESCRIPTION
Adds the `tool-panel` and `panel-bottom` classes to the prompt, to match other Atom panels and enable UI themes to work. Remove the `mini` class as it doesn't seem to do anything.

Also altered the capitalisation of "abbreviation" in the placeholder to match other placeholders in Atom.

![screen shot 2014-08-11 at 15 59 59](https://cloud.githubusercontent.com/assets/1759837/3877739/659f2c00-2168-11e4-9c65-04fbfff5fdb0.png)

![screen shot 2014-08-11 at 16 02 11](https://cloud.githubusercontent.com/assets/1759837/3877747/88953650-2168-11e4-9d15-552a760d552f.png)
