### PR TITLE
Obtain snippets main module via package manager

### DIFF
--- a/spec/emmet-spec.coffee
+++ b/spec/emmet-spec.coffee
@@ -88,7 +88,7 @@ describe "Emmet", ->
         cursorPos = editor.getCursorScreenPosition()
         expect(cursorPos.column).toBe 9
 
-      fit "expands HTML abbreviations via keybindings", ->
+      it "expands HTML abbreviations via keybindings", ->
         editorView.trigger keydownEvent('e', shiftKey: true, metaKey: true, target: editor[0])
         expect(editor.getText()).toBe expansion
         cursorPos = editor.getCursorScreenPosition()


### PR DESCRIPTION
The snippets package main module should be obtained via the `atom.packages` PackageManager instead of requiring directly.

Closes #155 
