### PR TITLE
Resolve deprecated atom selectors and workspaceView calls

### DIFF
--- a/lib/prompt.coffee
+++ b/lib/prompt.coffee
@@ -63,7 +63,7 @@ class PromptView extends View
 		if @previouslyFocusedElement?.isOnDom()
 			@previouslyFocusedElement.focus()
 		else
-			atom.workspaceView.focus()
+			#atom.workspaceView.focus()
 
 		super
 		@detaching = false
@@ -75,8 +75,10 @@ class PromptView extends View
 	attach: ->
 		@attached = true
 		@previouslyFocusedElement = $(':focus')
-		# atom.workspaceView.append(this)
-		atom.workspaceView.prependToBottom(this)
+		panelOpt = 
+			item: this
+			visible: true
+		atom.workspace.addBottomPanel(panelOpt)
 		@panelInput.focus()
 		@trigger 'attach'
 		method(@delegate, 'show')()

--- a/styles/emmet.less
+++ b/styles/emmet.less
@@ -25,7 +25,7 @@
 		transform: rotate(45deg);
 	}
 
-	.editor.mini {
+	atom-text-editor[mini] {
 		z-index: 1;
 		line-height: 16px;
 	}


### PR DESCRIPTION
I noticed a couple of deprecated issues when running emmet-atom, mainly around the "wrap with abbreviation" feature.

I have tested these changes in my own installation and via the specs, but please try them before accepting this PR.

Thanks!