### PR TITLE
Updating package because of Deprecation Cop errors

### DIFF
--- a/styles/emmet.less
+++ b/styles/emmet.less
@@ -25,7 +25,7 @@
 		transform: rotate(45deg);
 	}
 
-	.editor.mini {
+	.atom-text-editor[mini] {
 		z-index: 1;
 		line-height: 16px;
 	}


### PR DESCRIPTION
Deprecation Cop gives this error notification:

```
styles/emmet.less
    Use the `atom-text-editor` tag instead of the `editor` class.
    Use the selector `atom-text-editor[mini]` to select mini-editors.
```

![emmet-atom](https://cloud.githubusercontent.com/assets/275617/5961169/788c2ef0-a78f-11e4-84d2-5c0a38748a5c.png)
