### PR TITLE
Update editor-proxy.coffee to unescape text

### DIFF
--- a/lib/editor-proxy.coffee
+++ b/lib/editor-proxy.coffee
@@ -178,6 +178,7 @@ module.exports =
     start = 0 unless start?
 
     value = normalize(value, @editor)
+    value = utils.unescapeText(value)
     buf = @editor.getBuffer()
     changeRange = new Range(
       Point.fromObject(buf.positionForCharacterIndex(start)),


### PR DESCRIPTION
Just looking to create a solution for #133

Not sure if this is the right code location to make this change but it makes sense to me that the pastedContent should be unescaped since it gets escaped.

Thoughts?