### PR TITLE
Use a config schema instead of configDefaults.

### DIFF
--- a/lib/emmet.coffee
+++ b/lib/emmet.coffee
@@ -122,9 +122,13 @@ loadExtensions = () ->
     console.warn 'Emmet: no such extension folder:', extPath
 
 module.exports =
-  configDefaults:
-    extensionsPath: '~/emmet'
-    formatLineBreaks: true
+  config:
+    extensionsPath:
+      type: 'string'
+      default: '~/emmet'
+    formatLineBreaks:
+      type: 'boolean'
+      default: true
 
   activate: (@state) ->
     @subscriptions = new CompositeDisposable


### PR DESCRIPTION
Kills a Deprecation Cop warning.

configDefaults has been deprecated since v0.133.0:
https://github.com/atom/atom/commit/f57dbfd9f531c847f8e1ce34beab2b526f71
554c