### PR TITLE
Use TextEditor::lineTextForBufferRow(bufferRow).

### DIFF
--- a/lib/editor-proxy.coffee
+++ b/lib/editor-proxy.coffee
@@ -152,7 +152,7 @@ module.exports =
   getCurrentLine: ->
     sel = @getSelectionBufferRange()
     row = sel.getRows()[0]
-    return @editor.lineForBufferRow(row)
+    return @editor.lineTextForBufferRow(row)
 
   # Returns the editor content.
   getContent: ->


### PR DESCRIPTION
lineForBufferRow has been deprecated since v0.125.0: https://github.com/atom/atom/commit/b516f5a74d0589ed0e84627008e04f53871d