### PR TITLE
add emmet-comments option

### DIFF
--- a/lib/emmet.coffee
+++ b/lib/emmet.coffee
@@ -77,8 +77,8 @@ runAction = (action, evt) ->
         se.destroy()
       else
         return evt.abortKeyBinding()
-  
-  if action is 'toggle_comment' and toggleCommentSyntaxes.indexOf(syntax) is -1
+
+  if action is 'toggle_comment' and (toggleCommentSyntaxes.indexOf(syntax) is -1 or not atom.config.get 'emmet.useEmmetComments')
     return evt.abortKeyBinding()
 
   if action is 'insert_formatted_line_break_only'
@@ -129,6 +129,10 @@ module.exports =
     formatLineBreaks:
       type: 'boolean'
       default: true
+    useEmmetComments:
+      type: 'boolean'
+      default: true
+      description: 'disable to use atom native commenting system'
 
   activate: (@state) ->
     @subscriptions = new CompositeDisposable


### PR DESCRIPTION
Option in the package settings which allows to enable/disable the use of emmet comment system versus atom native comments.