### PR TITLE
Fixed keybinding conflict with setting-view:open

### DIFF
--- a/keymaps/emmet.cson
+++ b/keymaps/emmet.cson
@@ -1,6 +1,6 @@
 'atom-text-editor:not([mini])':
   'ctrl-e': 'emmet:expand-abbreviation'
-  'ctrl-,': 'emmet:balance-outward'
+  'ctrl-alt-,': 'emmet:balance-outward'
   'ctrl-shift-0': 'emmet:balance-inward'
   'ctrl-alt-j': 'emmet:matching-pair'
   'ctrl-alt-right': 'emmet:next-edit-point'


### PR DESCRIPTION
They is key-binding conflict with setting-view:open which is part of the core atom keybinding. I changed "Balance Outward" from `ctrl+,` to `ctrl+alt+,`.