### PR TITLE
Update package.json with license

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "emmet": "^1.3.1",
     "atom-space-pen-views": "^2.0.3"
   },
+  "license": "MIT",
   "repository": "https://github.com/emmetio/emmet-atom",
   "engines": {
     "atom": "*"


### PR DESCRIPTION
Tiny change, but it prevents an NPM warning for missing license.