### PR TITLE
fix syntax detection for jsx

### DIFF
--- a/lib/editor-proxy.coffee
+++ b/lib/editor-proxy.coffee
@@ -206,12 +206,12 @@ module.exports =
   # Returns the editor's syntax mode.
   getSyntax: ->
     syntax = @getGrammar().split(' ')[0]
-    unless resources.hasSyntax syntax
-        syntax = "html"
 
     if /\b(javascript|jsx)\b/.test(syntax)
       syntax = if @getCurrentScope().some((scope) -> /\bstring\b/.test scope) then 'html' else 'jsx'
-      
+    else if not resources.hasSyntax syntax
+      syntax = "html"
+
     if syntax is 'html'
       # HTML can contain embedded syntaxes
       embedded = @getCurrentScope().filter((s) -> /\.embedded\./.test s).pop()


### PR DESCRIPTION
This [commit](https://github.com/emmetio/emmet-atom/commit/75a050c998eb6805bc2c2eaba2e1c2ba17386ae5) breaks the syntax detection of jsx.

See the closed issue:
https://github.com/emmetio/emmet-atom/issues/237