### PR TITLE
Stylus preferences

### DIFF
--- a/keymaps/emmet.cson
+++ b/keymaps/emmet.cson
@@ -30,7 +30,7 @@
 
 # language-specific Tab triggers
 # you can add more triggers by changing `grammar` attribute values
-'atom-text-editor[data-grammar="text html basic"]:not([mini]), atom-text-editor[data-grammar~="erb"]:not([mini]), atom-text-editor[data-grammar~="jade"]:not([mini]), atom-text-editor[data-grammar~="css"]:not([mini]), atom-text-editor[data-grammar~="sass"]:not([mini])':
+'atom-text-editor[data-grammar="text html basic"]:not([mini]), atom-text-editor[data-grammar~="erb"]:not([mini]), atom-text-editor[data-grammar~="jade"]:not([mini]), atom-text-editor[data-grammar~="css"]:not([mini]), atom-text-editor[data-grammar~="stylus"]:not([mini]), atom-text-editor[data-grammar~="sass"]:not([mini])':
   'tab': 'emmet:expand-abbreviation-with-tab'
 
 '.platform-darwin atom-text-editor:not([mini])':

--- a/lib/emmet.coffee
+++ b/lib/emmet.coffee
@@ -17,6 +17,9 @@ singleSelectionActions = [
 
 toggleCommentSyntaxes = ['html', 'css', 'less', 'scss']
 
+for k, v of  atom.config.get 'emmet.stylus'
+    emmet.preferences.set('stylus.' + k, v);
+
 getUserHome = () ->
   if process.platform is 'win32'
     return process.env.USERPROFILE


### PR DESCRIPTION
It is currently possible to set Stylus properties in the GUI, but it does not seem like these are actually relayed to Emmet.

This PR addresses that, and also adds stylus to the grammars that trigger `emmet:expand-abbreviation-with-tab`.

This PR fixes issue #326. 