### PR TITLE
Make syntax test case-insensitive.

### DIFF
--- a/lib/editor-proxy.coffee
+++ b/lib/editor-proxy.coffee
@@ -207,7 +207,7 @@ module.exports =
   getSyntax: ->
     syntax = @getGrammar().split(' ')[0]
 
-    if /\b(javascript|jsx|babel)\b/.test(syntax)
+    if /\b(javascript|jsx|babel)\b/i.test(syntax)
       syntax = if @getCurrentScope().some((scope) -> /\bstring\b/.test scope) then 'html' else 'jsx'
     else if not resources.hasSyntax syntax
       syntax = "html"


### PR DESCRIPTION
When the syntax name contains `Babel` rather than `babel` the check fails (e.g., [`language-babel`](https://github.com/gandm/language-babel)).