### PR TITLE
enabled HTML (Angular) by default

### DIFF
--- a/keymaps/emmet.cson
+++ b/keymaps/emmet.cson
@@ -30,7 +30,7 @@
 
 # language-specific Tab triggers
 # you can add more triggers by changing `grammar` attribute values
-'atom-text-editor[data-grammar="text html basic"]:not([mini]), atom-text-editor[data-grammar~="erb"]:not([mini]), atom-text-editor[data-grammar~="jade"]:not([mini]), atom-text-editor[data-grammar~="css"]:not([mini]), atom-text-editor[data-grammar~="stylus"]:not([mini]), atom-text-editor[data-grammar~="sass"]:not([mini])':
+'atom-text-editor[data-grammar="text html basic"]:not([mini])','atom-text-editor[data-grammar="text html angular"]:not([mini]), atom-text-editor[data-grammar~="erb"]:not([mini]), atom-text-editor[data-grammar~="jade"]:not([mini]), atom-text-editor[data-grammar~="css"]:not([mini]), atom-text-editor[data-grammar~="stylus"]:not([mini]), atom-text-editor[data-grammar~="sass"]:not([mini])':
   'tab': 'emmet:expand-abbreviation-with-tab'
 
 '.platform-darwin atom-text-editor:not([mini])':

--- a/keymaps/emmet.cson
+++ b/keymaps/emmet.cson
@@ -30,7 +30,7 @@
 
 # language-specific Tab triggers
 # you can add more triggers by changing `grammar` attribute values
-'atom-text-editor[data-grammar="text html basic"]:not([mini])','atom-text-editor[data-grammar="text html angular"]:not([mini]), atom-text-editor[data-grammar~="erb"]:not([mini]), atom-text-editor[data-grammar~="jade"]:not([mini]), atom-text-editor[data-grammar~="css"]:not([mini]), atom-text-editor[data-grammar~="stylus"]:not([mini]), atom-text-editor[data-grammar~="sass"]:not([mini])':
+'atom-text-editor[data-grammar="text html basic"]:not([mini]),atom-text-editor[data-grammar="text html angular"]:not([mini]), atom-text-editor[data-grammar~="erb"]:not([mini]), atom-text-editor[data-grammar~="jade"]:not([mini]), atom-text-editor[data-grammar~="css"]:not([mini]), atom-text-editor[data-grammar~="stylus"]:not([mini]), atom-text-editor[data-grammar~="sass"]:not([mini])':
   'tab': 'emmet:expand-abbreviation-with-tab'
 
 '.platform-darwin atom-text-editor:not([mini])':


### PR DESCRIPTION
Avoid the burden of finding what is the grammar real name (here 'text html angular') and setting up
atom's keymap.cson

That should fix issue #343 "Emmet doesn't work with HTML(Angular) code style" 